### PR TITLE
refactor: Better encapsulation of subscription methods

### DIFF
--- a/global-types.d.ts
+++ b/global-types.d.ts
@@ -6,3 +6,6 @@ declare type SetOptions = {
 }
 declare type NotifySubscriberOptions = SetOptions
 declare type CurrentValueCallback = (currentValue: T) => T
+interface Subscription {
+  subscribe: (callback: UpdateMethod) => UnsubscribeFunction;
+}

--- a/src/hooks/useStore.ts
+++ b/src/hooks/useStore.ts
@@ -53,9 +53,10 @@ export function useStore<T>(controller: StoreController<T>) {
   stores.forEach(store => {
     const storeName: symbol = store.name
     const storeNameAsString: string = storeName.toString().slice(7, -1)
-    const camelizedName = camelize(storeNameAsString)
-    const onStoreUpdateMethodName = `on${camelize(storeNameAsString, true)}Update`
+    const camelizedName: string = camelize(storeNameAsString)
+    const onStoreUpdateMethodName: string = `on${camelize(storeNameAsString, true)}Update`
     const onStoreUpdateMethod = controller[onStoreUpdateMethodName] as (value: T) => void
+    const subscription: Subscription = store.getSubscription()
 
     if (onStoreUpdateMethod) {
       const updateMethod: (value: T) => void = value => {
@@ -65,7 +66,7 @@ export function useStore<T>(controller: StoreController<T>) {
       const methodName = `update${camelize(storeNameAsString, true)}`
       controller[methodName] = updateMethod
 
-      unsubscribeFunctions.push(store.subscribe(updateMethod))
+      unsubscribeFunctions.push(subscription.subscribe(updateMethod))
     }
 
     // Add a helper method to set the store value

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -40,8 +40,8 @@ export async function createStore<T>(options: StoreOptions<T>): Promise<Store<T>
   const { name, type, initialValue } = options
   checkInitialValue(initialValue)
   checkName(name)
-  const symbolName = Symbol(name)
   checkTypeConstructor(type?.name)
+  const symbolName = Symbol(name)
 
   const store: Store<T> = new Store<T>(symbolName, type)
   try {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -18,7 +18,7 @@ import { checkValue, handlePromiseError } from '../errors/storeErrorHandlers'
  */
 
 export class Store<T> {
-  name: symbol
+  readonly name: symbol
   private value!: T
   private subscribers: Set<UpdateMethod>
   private type: new (...args: unknown[]) => unknown
@@ -72,7 +72,7 @@ export class Store<T> {
    * @param {UpdateMethod} callback - The function to call when the store's value changes.
    * @returns {UnsubscribeFunction} A function that unsubscribes the callback.
    */
-  subscribe(callback: UpdateMethod): UnsubscribeFunction {
+  private subscribe(callback: UpdateMethod): UnsubscribeFunction {
     this.subscribers.add(callback)
     callback(this.get()) // Immediate call for initial value
     return () => this.unsubscribe(callback) // Return an unsubscribe function
@@ -83,8 +83,19 @@ export class Store<T> {
    *
    * @param {UpdateMethod} callback - The function to unsubscribe.
    */
-  unsubscribe(callback: UpdateMethod) {
+  private unsubscribe(callback: UpdateMethod) {
     this.subscribers.delete(callback)
+  }
+
+  /**
+   * Gets a subscription object with subscribe, when invoked subscribe returns an unsubscribe function.
+   *
+   * @returns {Subscription} A subscription object.
+   */
+  public getSubscription(): Subscription {
+    return {
+      subscribe: (callback: UpdateMethod) => this.subscribe(callback)
+    }
   }
 
   private notifySubscribers(options: NotifySubscriberOptions) {

--- a/test/hooks/useStore.test.ts
+++ b/test/hooks/useStore.test.ts
@@ -61,8 +61,16 @@ describe('useStore', () => {
   })
 
   it('should clean up subscriptions when controller disconnects', () => {
-    const unsubscribe = jest.spyOn(testStore, 'unsubscribe')
+    const unsubscribe = jest.fn()
+    jest.spyOn(testStore, 'getSubscription').mockReturnValue({
+      subscribe: () => unsubscribe
+    })
+
+    // Call useStore to trigger the subscription
+    useStore(mockController)
+
     mockController.disconnect()
+
     expect(unsubscribe).toHaveBeenCalled()
   })
 

--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -18,7 +18,7 @@ describe('Store', () => {
 
   it('should notify subscribers when value changes', () => {
     const mockCallback = jest.fn()
-    store.subscribe(mockCallback)
+    store.getSubscription().subscribe(mockCallback)
 
     store.set(10)
     expect(mockCallback).toHaveBeenCalledWith(10)
@@ -26,7 +26,7 @@ describe('Store', () => {
 
   it('should stop notifying unsubscribed callbacks', () => {
     const mockCallback = jest.fn()
-    const unsubscribe = store.subscribe(mockCallback)
+    const unsubscribe = store.getSubscription().subscribe(mockCallback)
 
     unsubscribe()
     store.set(15)
@@ -40,7 +40,7 @@ describe('Store', () => {
     await store.set(0)
 
     // Subscribe to the store and invoke the callback
-    store.subscribe(mockCallback)
+    store.getSubscription().subscribe(mockCallback)
 
     // Second set: change value to 1 and invoke the callback
     await store.set(1)
@@ -54,7 +54,7 @@ describe('Store', () => {
 
   it('should not notify subscribers when filter returns false', async () => {
     const mockCallback = jest.fn()
-    store.subscribe(mockCallback)
+    store.getSubscription().subscribe(mockCallback)
 
     await store.set(20, { filter: () => false })
     expect(mockCallback).not.toHaveBeenCalledWith(20)


### PR DESCRIPTION
Make store `subscribe` and `unsubscribe` private and introduce a new `getSubscription` method for controlled access to the subscription.